### PR TITLE
Fix CVE vulnerabilities in image-build-el10 container

### DIFF
--- a/ContainerFile/image-build/Dockerfile.el10
+++ b/ContainerFile/image-build/Dockerfile.el10
@@ -1,5 +1,8 @@
 FROM docker.io/library/almalinux:10.0
 
+ARG BUILDAH_VERSION=1.42.2
+ARG GO_VERSION=1.24.3
+
 RUN dnf clean all && \
     dnf update -y --releasever=10.0 --nogpgcheck && \
     dnf install -y dnf-plugins-core epel-release && \
@@ -8,16 +11,43 @@ RUN dnf clean all && \
 
 RUN dnf install -y \
         bash \
-        buildah \
         python3.12 \
         python3.12-pip \
         fuse-overlayfs \
         tar \
         squashfs-tools \
+        make \
+        gcc \
+        glib2-devel \
+        gpgme-devel \
+        libseccomp-devel \
+        libselinux-devel \
+        device-mapper-devel \
+        btrfs-progs-devel \
+        git \
+        wget
+
+RUN wget -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
+    rm go${GO_VERSION}.linux-amd64.tar.gz
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+RUN git clone --branch v${BUILDAH_VERSION} --depth 1 https://github.com/containers/buildah.git /tmp/buildah && \
+    cd /tmp/buildah && \
+    make buildah && \
+    cp bin/buildah /usr/bin/buildah && \
+    rm -rf /tmp/buildah /usr/local/go
+
+RUN dnf install -y \
+        containers-common \
+        crun \
+        slirp4netns \
         fuse-overlayfs
 
 COPY requirements.txt /
-RUN pip install -r /requirements.txt
+RUN pip install --upgrade pip>=25.3 && \
+    pip install -r /requirements.txt
 
 COPY src/ /usr/local/bin/
 RUN chmod -R 0755 /usr/local/bin/

--- a/ContainerFile/image-build/Dockerfile.el10
+++ b/ContainerFile/image-build/Dockerfile.el10
@@ -52,8 +52,9 @@ RUN dnf install -y \
         fuse-overlayfs
 
 COPY requirements.txt /
-RUN python3.12 -m pip install --upgrade pip && \
-    pip install -r /requirements.txt
+RUN pip install --upgrade pip && \
+    pip install -r /requirements.txt && \
+    rm -rf /usr/lib/python3.12/site-packages/pip*
 
 COPY src/ /usr/local/bin/
 RUN chmod -R 0755 /usr/local/bin/

--- a/ContainerFile/image-build/Dockerfile.el10
+++ b/ContainerFile/image-build/Dockerfile.el10
@@ -39,6 +39,7 @@ RUN git clone --branch v${BUILDAH_VERSION} --depth 1 https://github.com/containe
     go get golang.org/x/crypto@v0.45.0 && \
     go get github.com/containernetworking/plugins@v1.9.0 && \
     go mod tidy && \
+    go mod vendor && \
     make buildah && \
     cp bin/buildah /usr/bin/buildah && \
     rm -rf /tmp/buildah /usr/local/go

--- a/ContainerFile/image-build/Dockerfile.el10
+++ b/ContainerFile/image-build/Dockerfile.el10
@@ -39,6 +39,7 @@ RUN git clone --branch v${BUILDAH_VERSION} --depth 1 https://github.com/containe
     go get golang.org/x/crypto@v0.45.0 && \
     go get github.com/containernetworking/plugins@v1.9.0 && \
     go mod tidy && \
+    go get github.com/sigstore/fulcio@v1.8.5 && \
     go mod vendor && \
     make buildah && \
     cp bin/buildah /usr/bin/buildah && \
@@ -51,7 +52,7 @@ RUN dnf install -y \
         fuse-overlayfs
 
 COPY requirements.txt /
-RUN pip install --upgrade "pip>=25.3" && \
+RUN python3.12 -m pip install --upgrade pip && \
     pip install -r /requirements.txt
 
 COPY src/ /usr/local/bin/

--- a/ContainerFile/image-build/Dockerfile.el10
+++ b/ContainerFile/image-build/Dockerfile.el10
@@ -1,7 +1,7 @@
 FROM docker.io/library/almalinux:10.0
 
 ARG BUILDAH_VERSION=1.42.2
-ARG GO_VERSION=1.24.11
+ARG GO_VERSION=1.25.5
 
 RUN dnf clean all && \
     dnf update -y --releasever=10.0 --nogpgcheck && \
@@ -51,7 +51,7 @@ RUN dnf install -y \
         fuse-overlayfs
 
 COPY requirements.txt /
-RUN pip install --upgrade pip>=25.3 && \
+RUN pip install --upgrade "pip>=25.3" && \
     pip install -r /requirements.txt
 
 COPY src/ /usr/local/bin/

--- a/ContainerFile/image-build/Dockerfile.el10
+++ b/ContainerFile/image-build/Dockerfile.el10
@@ -35,6 +35,10 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 
 RUN git clone --branch v${BUILDAH_VERSION} --depth 1 https://github.com/containers/buildah.git /tmp/buildah && \
     cd /tmp/buildah && \
+    go get github.com/sigstore/fulcio@v1.8.5 && \
+    go get golang.org/x/crypto@v0.45.0 && \
+    go get github.com/containernetworking/plugins@v1.9.0 && \
+    go mod tidy && \
     make buildah && \
     cp bin/buildah /usr/bin/buildah && \
     rm -rf /tmp/buildah /usr/local/go

--- a/ContainerFile/image-build/Dockerfile.el10
+++ b/ContainerFile/image-build/Dockerfile.el10
@@ -12,7 +12,6 @@ RUN dnf clean all && \
 RUN dnf install -y \
         bash \
         python3.12 \
-        python3.12-pip \
         fuse-overlayfs \
         tar \
         squashfs-tools \
@@ -52,9 +51,9 @@ RUN dnf install -y \
         fuse-overlayfs
 
 COPY requirements.txt /
-RUN pip install --upgrade pip && \
-    pip install -r /requirements.txt && \
-    rm -rf /usr/lib/python3.12/site-packages/pip*
+RUN python3.12 -m ensurepip && \
+    python3.12 -m pip install --upgrade pip && \
+    python3.12 -m pip install -r /requirements.txt
 
 COPY src/ /usr/local/bin/
 RUN chmod -R 0755 /usr/local/bin/

--- a/ContainerFile/image-build/Dockerfile.el10
+++ b/ContainerFile/image-build/Dockerfile.el10
@@ -1,7 +1,7 @@
 FROM docker.io/library/almalinux:10.0
 
 ARG BUILDAH_VERSION=1.42.2
-ARG GO_VERSION=1.24.3
+ARG GO_VERSION=1.24.11
 
 RUN dnf clean all && \
     dnf update -y --releasever=10.0 --nogpgcheck && \

--- a/ContainerFile/image-build/Dockerfile.el10
+++ b/ContainerFile/image-build/Dockerfile.el10
@@ -42,7 +42,10 @@ RUN git clone --branch v${BUILDAH_VERSION} --depth 1 https://github.com/containe
     go mod vendor && \
     make buildah && \
     cp bin/buildah /usr/bin/buildah && \
-    rm -rf /tmp/buildah /usr/local/go
+    rm -rf /tmp/buildah /usr/local/go /root/go && \
+    dnf remove -y --noautoremove make gcc git wget glib2-devel gpgme-devel libseccomp-devel libselinux-devel device-mapper-devel btrfs-progs-devel && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
 
 RUN dnf install -y \
         containers-common \

--- a/ContainerFile/image-build/requirements.txt
+++ b/ContainerFile/image-build/requirements.txt
@@ -4,3 +4,4 @@ dnspython
 jinja2_ansible_filters
 PyYAML
 requests
+urllib3>=2.6.3


### PR DESCRIPTION
This PR addresses all reported CVE vulnerabilities in the image-build-el10 container:
 
### Changes Made:
1. **Build buildah from source** with Go 1.25.5 to fix Go stdlib vulnerabilities
2. **Patch buildah dependencies** to secure versions:
   - github.com/sigstore/fulcio@v1.8.5
   - golang.org/x/crypto@v0.45.0
   - github.com/containernetworking/plugins@v1.9.0
3. **Fix pip vulnerability** by using ensurepip instead of python3.12-pip package
4. **Optimize image size** by removing build dependencies with --noautoremove
5. **Use ansible-core only** instead of full ansible package to reduce bloat

 