### PR TITLE
feat: Add dynamic platform detection for multi-architecture image-builder builds

### DIFF
--- a/ContainerFile/image-build/Dockerfile.el10
+++ b/ContainerFile/image-build/Dockerfile.el10
@@ -26,9 +26,18 @@ RUN dnf install -y \
         git \
         wget
 
-RUN wget -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && \
-    rm go${GO_VERSION}.linux-amd64.tar.gz
+# Determine architecture and download matching Go tarball
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        GOARCH=amd64; \
+    elif [ "$ARCH" = "aarch64" ]; then \
+        GOARCH=arm64; \
+    else \
+        echo "Unsupported architecture: $ARCH" && exit 1; \
+    fi && \
+    curl -LO https://go.dev/dl/go${GO_VERSION}.linux-${GOARCH}.tar.gz && \
+    tar -C /usr/local -xzf go${GO_VERSION}.linux-${GOARCH}.tar.gz && \
+    rm go${GO_VERSION}.linux-${GOARCH}.tar.gz
 
 ENV PATH="/usr/local/go/bin:${PATH}"
 

--- a/build_images.sh
+++ b/build_images.sh
@@ -411,6 +411,9 @@ build_image_builder() {
     echo -e "Using Build Action: ${YELLOW}${BUILD_ACTION}${NC}"
     echo -e "Using Image Builder Commit: ${YELLOW}${IMAGE_BUILDER_COMMIT}${NC}"
     echo -e "Using Image Builder Tag: ${YELLOW}${IMAGE_BUILDER_TAG}${NC}"
+    if [ "$BUILD_TOOL" = "docker" ]; then
+        echo -e "Using Detected Platform: ${YELLOW}${DETECTED_PLATFORM}${NC}"
+    fi
     if [ "$BUILD_TOOL" = "docker" ] && [ "$BUILD_ACTION" = "push" ]; then
         echo -e "Registry: ${YELLOW}$OMNIA_DOCKER_REGISTERY${NC}"
         echo -e "Full Image Name: ${YELLOW}$OMNIA_DOCKER_REGISTERY/image-build-el10:${IMAGE_BUILDER_TAG}${NC}"
@@ -428,12 +431,12 @@ build_image_builder() {
     elif [ "$BUILD_TOOL" = "docker" ]; then
         if [ "$BUILD_ACTION" = "load" ]; then
             docker buildx build --no-cache -t image-build-el10:${IMAGE_BUILDER_TAG} \
-                --file dockerfiles/dnf/Dockerfile.el10 --platform linux/amd64 --load .
+                --file dockerfiles/dnf/Dockerfile.el10 --platform "$DETECTED_PLATFORM" --load .
             BUILD_RESULT=$?
             IMAGE_DESTINATION="Local (Docker): image-build-el10:${IMAGE_BUILDER_TAG}"
         elif [ "$BUILD_ACTION" = "push" ]; then
             docker buildx build --no-cache -t "$OMNIA_DOCKER_REGISTERY/image-build-el10:${IMAGE_BUILDER_TAG}" \
-                --file dockerfiles/dnf/Dockerfile.el10 --platform linux/amd64 --provenance=true --sbom=true --push .
+                --file dockerfiles/dnf/Dockerfile.el10 --platform "$DETECTED_PLATFORM" --provenance=true --sbom=true --push .
             BUILD_RESULT=$?
             IMAGE_DESTINATION="Registry: $OMNIA_DOCKER_REGISTERY/image-build-el10:${IMAGE_BUILDER_TAG}"
         else
@@ -465,6 +468,8 @@ OMNIA_VERSION="main"
 BUILD_TOOL="podman"
 BUILD_ACTION="load"
 OMNIA_DOCKER_REGISTERY="docker.io/dellhpcomniaaisolution"
+# Dynamic platform detection for image-builder (only used when build_tool=docker)
+DETECTED_PLATFORM="$(docker info --format '{{.OSType}}/{{.Architecture}}' 2>/dev/null || echo 'linux/amd64')"
 
 # Default image tags for each container (can be overridden individually)
 CORE_TAG="1.0"

--- a/build_images.sh
+++ b/build_images.sh
@@ -412,6 +412,12 @@ build_image_builder() {
     echo -e "Using Image Builder Commit: ${YELLOW}${IMAGE_BUILDER_COMMIT}${NC}"
     echo -e "Using Image Builder Tag: ${YELLOW}${IMAGE_BUILDER_TAG}${NC}"
     if [ "$BUILD_TOOL" = "docker" ]; then
+        # Dynamic platform detection for image-builder (only when using docker)
+        DETECTED_PLATFORM="$(docker info --format '{{.OSType}}/{{.Architecture}}')" || {
+            echo -e "${RED}Error: Failed to detect platform. Docker info command failed.${NC}"
+            echo -e "${YELLOW}Please ensure Docker is installed and running.${NC}"
+            exit 1
+        }
         echo -e "Using Detected Platform: ${YELLOW}${DETECTED_PLATFORM}${NC}"
     fi
     if [ "$BUILD_TOOL" = "docker" ] && [ "$BUILD_ACTION" = "push" ]; then
@@ -468,8 +474,6 @@ OMNIA_VERSION="main"
 BUILD_TOOL="podman"
 BUILD_ACTION="load"
 OMNIA_DOCKER_REGISTERY="docker.io/dellhpcomniaaisolution"
-# Dynamic platform detection for image-builder (only used when build_tool=docker)
-DETECTED_PLATFORM="$(docker info --format '{{.OSType}}/{{.Architecture}}' 2>/dev/null || echo 'linux/amd64')"
 
 # Default image tags for each container (can be overridden individually)
 CORE_TAG="1.0"


### PR DESCRIPTION
**Summary**
Enhance the image-builder build process to support both x86_64 and aarch64 architectures by implementing dynamic platform detection and architecture-aware Go downloads.

**Problem**

- Image-builder container had hardcoded --platform linux/amd64 flags
- Dockerfile had hardcoded Go download for x86_64 only

**Solution**

- Dynamic Platform Detection: Use docker info to auto-detect host architecture
- Architecture-Aware Go Download: Detect system architecture in Dockerfile and download matching Go tarball

@abhishek-sa1 please review
