### PR TITLE
fix: KeyError in OIM Prerequisite Check - Missing Message Keys

### DIFF
--- a/automation_library/checks/functions/repository.py
+++ b/automation_library/checks/functions/repository.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright 2026 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -132,7 +132,7 @@ def clone_omnia_repo() -> Dict:
         return {
             "passed": False,
             "message": "Omnia repository URL not configured",
-            "details": OIM_PREREQ_MSGS["omnia_repo_omnia_test_configured_instruction"].format(config_path=OMNIA_TEST_CONFIG_PATH)
+            "details": OIM_PREREQ_MSGS["omnia_repo_not_configured_instruction"].format(config_path=OMNIA_TEST_CONFIG_PATH)
         }
 
     _log(f"Repo URL: {repo_url}", "DEBUG")
@@ -184,7 +184,7 @@ def build_container_images() -> Dict:
         return {
             "passed": False,
             "message": "omnia_branch not configured",
-            "details": OIM_PREREQ_MSGS["omnia_branch_omnia_test_configured"].format(config_path=OMNIA_TEST_CONFIG_PATH)
+            "details": OIM_PREREQ_MSGS["omnia_branch_not_configured"].format(config_path=OMNIA_TEST_CONFIG_PATH)
         }
 
     # Check if clone path exists
@@ -246,7 +246,7 @@ def download_omnia_sh() -> Dict:
         return {
             "passed": False,
             "message": "omnia_branch not configured",
-            "details": OIM_PREREQ_MSGS["omnia_sh_branch_omnia_test_configured"].format(config_path=OMNIA_TEST_CONFIG_PATH)
+            "details": OIM_PREREQ_MSGS["omnia_sh_branch_not_configured"].format(config_path=OMNIA_TEST_CONFIG_PATH)
         }
 
     # Create directory if it doesn't exist

--- a/run_prereq_check.py
+++ b/run_prereq_check.py
@@ -38,7 +38,7 @@ import os
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from automation_library.checks.functions.main import run_all_prereq_checks
-from automation_library.core.formatting import set_debug_mode
+from automation_library.core import set_debug_mode
 
 
 def main():


### PR DESCRIPTION
Fixed three incorrect message key references in automation_library/checks/functions/repository.py that were causing KeyError exceptions when running OIM prerequisite checks.

Issue
When running oim-prereq-check or run_prereq_check.py, the script crashed with KeyError: 'omnia_sh_branch_omnia_test_configured' when omnia_branch was not configured. This prevented users from seeing helpful error messages about missing configuration.

Root Cause
The code referenced non-existent message keys with incorrect naming patterns:

*_omnia_test_configured instead of *_not_configured
Changes
Fixed 3 message key references in repository.py:

Line 249: omnia_sh_branch_omnia_test_configured → omnia_sh_branch_not_configured
Line 135: omnia_repo_omnia_test_configured_instruction → omnia_repo_not_configured_instruction
Line 187: omnia_branch_omnia_test_configured → omnia_branch_not_configure

@abhishek-sa1 please review