### PR TITLE
Update converge.yml

### DIFF
--- a/molecule/provision/converge.yml
+++ b/molecule/provision/converge.yml
@@ -290,11 +290,10 @@
     # =========================================================================
 
     - name: Check if set_pxe_boot playbook exists in container
-      ansible.builtin.shell:  # noqa: risky-shell-pipe
+      ansible.builtin.shell:
         cmd: >
           podman exec {{ container_name }}
-          bash -o pipefail -c
-          'ls /omnia/utils/set_pxe_boot.yml /omnia/provision/set_pxe_boot.yml 2>/dev/null | head -1'
+          test -f /omnia/utils/set_pxe_boot.yml && echo '/omnia/utils/set_pxe_boot.yml' || echo ''
       register: pxe_boot_playbook_check
       changed_when: false
 


### PR DESCRIPTION
fix(provision): fix set_pxe_boot playbook existence check failing with rc=2

The Check if set_pxe_boot playbook exists in container task in the provision converge was failing with return code 2, even though the playbook file was found successfully.