### PR TITLE
fix: provision skip logic for vector, minimal_os, dns, and slurm

### DIFF
--- a/automation_library/telemetry/functions/__init__.py
+++ b/automation_library/telemetry/functions/__init__.py
@@ -49,6 +49,10 @@ from .shared_func import (
     is_powerscale_metrics_enabled,
     is_powerscale_logs_enabled,
     skip_if_powerscale_not_enabled,
+    # Vector bridge checks
+    is_vector_ldms_enabled,
+    is_vector_ome_enabled,
+    skip_if_vector_not_enabled,
 )
 
 from .kafka_func import (

--- a/automation_library/telemetry/functions/shared_func.py
+++ b/automation_library/telemetry/functions/shared_func.py
@@ -216,6 +216,59 @@ def is_ldms_enabled(host) -> bool:
     return False
 
 
+def is_vector_ldms_enabled(host) -> bool:
+    """
+    Check if Vector-LDMS bridge is enabled in telemetry_config.yml.
+
+    Checks telemetry_bridges.vector_ldms.metrics_enabled.
+
+    Returns:
+        True if vector_ldms metrics_enabled is true
+    """
+    config = get_telemetry_config(host)
+    bridges = config.get("telemetry_bridges", {})
+    vector_ldms = bridges.get("vector_ldms", {})
+    return bool(vector_ldms.get("metrics_enabled", False))
+
+
+def is_vector_ome_enabled(host) -> bool:
+    """
+    Check if Vector-OME bridge is enabled in telemetry_config.yml.
+
+    Checks telemetry_bridges.vector_ome.metrics_enabled or logs_enabled.
+
+    Returns:
+        True if vector_ome metrics_enabled or logs_enabled is true
+    """
+    config = get_telemetry_config(host)
+    bridges = config.get("telemetry_bridges", {})
+    vector_ome = bridges.get("vector_ome", {})
+    return bool(
+        vector_ome.get("metrics_enabled", False)
+        or vector_ome.get("logs_enabled", False)
+    )
+
+
+def skip_if_vector_not_enabled(host, log):
+    """
+    Skip test if neither Vector-LDMS nor Vector-OME is enabled.
+
+    Args:
+        host: Testinfra host object
+        log: TestLogger instance
+    """
+    if not is_vector_ldms_enabled(host) and not is_vector_ome_enabled(host):
+        log.skipped(
+            "Vector bridges not enabled (vector_ldms and vector_ome "
+            "are both disabled in telemetry_config.yml)",
+            "Test skipped — enable vector_ldms or vector_ome in "
+            "telemetry_config.yml to run this test"
+        )
+        pytest.skip(
+            "Vector bridges not enabled in telemetry_config.yml"
+        )
+
+
 # =============================================================================
 # SERVICE TAG FUNCTIONS
 # =============================================================================

--- a/molecule/conftest.py
+++ b/molecule/conftest.py
@@ -153,6 +153,11 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "security: marks tests as security verification (permissions, access control)")
     config.addinivalue_line("markers", "rollback: marks tests as rollback verification (post-rollback state)")
     config.addinivalue_line("markers", "idempotency: marks tests as idempotency verification (re-run consistency)")
+    # Domain-specific markers
+    config.addinivalue_line("markers", "dns: marks tests as DNS / CoreDNS tests")
+    config.addinivalue_line("markers", "minimal_os: marks tests as minimal OS verification tests")
+    config.addinivalue_line("markers", "sanitygpu: marks tests as GPU sanity tests")
+    config.addinivalue_line("markers", "ufm_telemetry: marks tests as UFM telemetry tests")
 
     # DCGM GPU node collection - only for dcgm scenario
     _collect_dcgm_gpu_nodes(config)
@@ -195,14 +200,12 @@ def _collect_dcgm_gpu_nodes(config):
 
     try:
         from automation_library.dcgm.functions import get_gpu_nodes, get_login_compiler_nodes
-        from automation_library.dcgm.messages import TEST_ASSERT_MSGS as ASSERT
-
         host = get_testinfra_host()
-        
+
         # Collect GPU nodes
         nodes = get_gpu_nodes(host)
         _gpu_node_ips = [node["admin_ip"] for node in nodes] if nodes else []
-        
+
         # Collect login_compiler nodes
         lc_nodes = get_login_compiler_nodes(host)
         _login_compiler_ips = [node["admin_ip"] for node in lc_nodes] if lc_nodes else []
@@ -289,11 +292,15 @@ def pytest_generate_tests(metafunc):
                 _gpu_node_ips,
                 ids=_gpu_node_ips,
             )
-    
+
     # Parametrize login_compiler_ip
     if "login_compiler_ip" in metafunc.fixturenames:
         if not _login_compiler_ips:
-            reason = _login_compiler_collection_error if _login_compiler_collection_error else "No login_compiler nodes found"
+            reason = (
+                _login_compiler_collection_error
+                if _login_compiler_collection_error
+                else "No login_compiler nodes found"
+            )
             metafunc.parametrize(
                 "login_compiler_ip",
                 [pytest.param(None, marks=pytest.mark.skip(reason=reason))],
@@ -612,7 +619,7 @@ def _require_build_stream_job(host, request):
         # Put detailed error in log.skipped details (with proper line breaks)
         short_skip_reason = job_state
         detailed_error = f"build_stream job is {job_state} — skipping test.\nFix: {error}"
-        
+
         log.skipped(
             f"Skipped due to build_stream job failure (job_id: {job_id})",
             detailed_error

--- a/molecule/provision/tests/sanity/test_coredns.py
+++ b/molecule/provision/tests/sanity/test_coredns.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pylint: disable=too-many-lines
 """
 CoreDNS Test Cases for Provision Module.
 
@@ -226,8 +227,11 @@ def test_dns_configuration_enable(host):
     dns_enabled = check_dns_enabled(host)
 
     if not dns_enabled:
-        log.failed("DNS is not enabled", "Set dns_enabled: true in provision_config.yml")
-        assert False, "dns_enabled is not set to true"
+        log.skipped(
+            "DNS is not enabled (dns_enabled: false in provision_config.yml)",
+            "Skipped \u2014 set dns_enabled: true in provision_config.yml to run DNS tests"
+        )
+        pytest.skip("dns_enabled is false in provision_config.yml")
 
     log.check("Verifying coresmd-coredns container is running")
     container_status = get_coresmd_container_status(host)
@@ -250,6 +254,10 @@ def test_dns_configuration_enable(host):
 def test_coresmd_container_deployment(host):
     """TC-F11: Verify coresmd container is deployed correctly."""
     log = TestLogger("3. coresmd Container Deployment")
+
+    if not check_dns_enabled(host):
+        log.skipped("DNS is not enabled", "Enable DNS in provision_config.yml")
+        pytest.skip("DNS is not enabled")
 
     log.check("Verifying coresmd-coredns container deployment")
     container_status = get_coresmd_container_status(host)
@@ -743,6 +751,10 @@ def test_dns_configuration_validation(host):
     """
     log = TestLogger("2. Valid DNS Configuration File")
 
+    if not check_dns_enabled(host):
+        log.skipped("DNS is not enabled", "Enable DNS in provision_config.yml")
+        pytest.skip("DNS is not enabled")
+
     log.check("Validating DNS configuration")
 
     cmd = run_in_container(
@@ -980,6 +992,10 @@ def test_backward_compatibility_dns_disabled(host):
 def test_invalid_domain_format_validation(host):
     """TC-E01: Verify invalid domain format is rejected during validation."""
     log = TestLogger("16. Invalid Domain Format - Uppercase Characters")
+
+    if not check_dns_enabled(host):
+        log.skipped("DNS is not enabled", "Enable DNS in provision_config.yml")
+        pytest.skip("DNS is not enabled")
 
     log.check("Validating DNS domain format")
 

--- a/molecule/provision/tests/sanity/test_minimal_os.py
+++ b/molecule/provision/tests/sanity/test_minimal_os.py
@@ -35,6 +35,7 @@ from automation_library.provision.messages import (  # pylint: disable=import-er
 )
 from automation_library.provision.functions import (  # pylint: disable=import-error,no-name-in-module
     get_test_node,
+    get_minimal_os_nodes,
     check_functional_groups,
     validate_node_architecture,
     check_base_packages,
@@ -50,6 +51,16 @@ from automation_library.provision.functions import (  # pylint: disable=import-e
 )
 
 
+def _skip_if_no_minimal_os(host):
+    """Skip test if no os_x86_64 or os_aarch64 functional groups in PXE mapping."""
+    nodes = get_minimal_os_nodes(host)
+    if not nodes:
+        pytest.skip(
+            "Skipped \u2014 no os_x86_64 or os_aarch64 functional groups "
+            "found in pxe_mapping_file.csv"
+        )
+
+
 # =============================================================================
 # TC-F01: FUNCTIONAL GROUP SCHEMA VALIDATION
 # =============================================================================
@@ -63,6 +74,7 @@ def test_functional_group_schema(host):
     Verifies that os_x86_64 and os_aarch64 functional groups are properly
     defined in the OIM configuration.
     """
+    _skip_if_no_minimal_os(host)
     log = TestLogger(TEST_NAMES["schema_validation"])
 
     log.check("Checking for minimal OS functional groups")
@@ -90,6 +102,7 @@ def test_architecture_x86_64(host):
 
     Verifies that x86_64 nodes report correct architecture.
     """
+    _skip_if_no_minimal_os(host)
     log = TestLogger(TEST_NAMES["arch_x86_64"])
 
     node = get_test_node(host, "os_x86_64")
@@ -130,6 +143,7 @@ def test_architecture_aarch64(host):
 
     Verifies that aarch64 nodes report correct architecture.
     """
+    _skip_if_no_minimal_os(host)
     log = TestLogger(TEST_NAMES["arch_aarch64"])
 
     node = get_test_node(host, "os_aarch64")
@@ -170,6 +184,7 @@ def test_base_packages(host):
 
     Verifies that all required base OS packages are installed on minimal OS nodes.
     """
+    _skip_if_no_minimal_os(host)
     log = TestLogger(TEST_NAMES["base_packages"])
 
     node = get_test_node(host)
@@ -204,6 +219,7 @@ def test_ldms_packages(host):
     Verifies that LDMS packages are installed on minimal OS nodes.
     Minimal OS supports LDMS for monitoring.
     """
+    _skip_if_no_minimal_os(host)
     log = TestLogger(TEST_NAMES["ldms_packages"])
 
     node = get_test_node(host)
@@ -237,6 +253,7 @@ def test_excluded_packages(host):
 
     Verifies that excluded packages (Slurm, K8s, CUDA, etc.) are NOT installed.
     """
+    _skip_if_no_minimal_os(host)
     log = TestLogger(TEST_NAMES["excluded_packages"])
 
     node = get_test_node(host)
@@ -271,6 +288,7 @@ def test_additional_packages(host):
     Verifies that additional packages from additional_packages.json are installed.
     Minimal OS supports custom packages via additional_packages.json.
     """
+    _skip_if_no_minimal_os(host)
     log = TestLogger(TEST_NAMES["additional_packages"])
 
     node = get_test_node(host)
@@ -312,6 +330,7 @@ def test_additional_packages_fallback(host):
 
     Verifies system works correctly when no additional packages are configured.
     """
+    _skip_if_no_minimal_os(host)
     log = TestLogger(TEST_NAMES["no_additional_packages"])
 
     node = get_test_node(host)
@@ -345,6 +364,7 @@ def test_network_identity(host):
 
     Verifies that nodes have correct hostname and IP configuration.
     """
+    _skip_if_no_minimal_os(host)
     log = TestLogger(TEST_NAMES["network_identity"])
 
     node = get_test_node(host)
@@ -378,6 +398,7 @@ def test_handoff_services(host):
 
     Verifies that required services are running at handoff.
     """
+    _skip_if_no_minimal_os(host)
     log = TestLogger(TEST_NAMES["handoff_services"])
 
     node = get_test_node(host)
@@ -411,6 +432,7 @@ def test_ssh_access(host):
 
     Verifies SSH key-based authentication is working.
     """
+    _skip_if_no_minimal_os(host)
     log = TestLogger(TEST_NAMES["ssh_access"])
 
     node = get_test_node(host)
@@ -455,6 +477,7 @@ def test_package_manager(host):
 
     Verifies that dnf/yum package manager is functional.
     """
+    _skip_if_no_minimal_os(host)
     log = TestLogger(TEST_NAMES["package_manager"])
 
     node = get_test_node(host)
@@ -489,6 +512,7 @@ def test_ldms_service_state(host):
     Verifies that LDMS service is installed but NOT running at handoff.
     LDMS will be started by downstream platform (RKE2).
     """
+    _skip_if_no_minimal_os(host)
     log = TestLogger(TEST_NAMES["ldms_not_running"])
 
     node = get_test_node(host)
@@ -521,6 +545,7 @@ def test_architecture_mismatch_detection(host):
 
     Verifies that architecture validation is enforced.
     """
+    _skip_if_no_minimal_os(host)
     log = TestLogger(TEST_NAMES["arch_mismatch"])
 
     log.check("Verifying architecture validation is enforced")
@@ -556,6 +581,7 @@ def test_missing_image_detection(host):  # pylint: disable=unused-argument
     Args:
         host: Testinfra host (unused - kept for pytest fixture compatibility)
     """
+    _skip_if_no_minimal_os(host)
     log = TestLogger(TEST_NAMES["missing_image"])
 
     log.check("Verifying image detection capability")
@@ -577,6 +603,7 @@ def test_invalid_packages_handling(host):
 
     Verifies graceful handling of invalid additional packages configuration.
     """
+    _skip_if_no_minimal_os(host)
     log = TestLogger(TEST_NAMES["invalid_packages"])
 
     node = get_test_node(host)
@@ -612,6 +639,7 @@ def test_network_isolation(host):
 
     Verifies that provisioning traffic is confined to management network.
     """
+    _skip_if_no_minimal_os(host)
     log = TestLogger(TEST_NAMES["network_isolation"])
 
     node = get_test_node(host)
@@ -647,6 +675,7 @@ def test_ssh_key_access(host):
 
     Verifies SSH key-based authentication is enforced.
     """
+    _skip_if_no_minimal_os(host)
     log = TestLogger(TEST_NAMES["ssh_key_access"])
 
     node = get_test_node(host)
@@ -681,6 +710,7 @@ def test_no_embedded_credentials(host):
 
     Verifies that no credentials are embedded in the OS image.
     """
+    _skip_if_no_minimal_os(host)
     log = TestLogger(TEST_NAMES["no_credentials"])
 
     node = get_test_node(host)

--- a/molecule/provision/tests/sanity/test_slurm.py
+++ b/molecule/provision/tests/sanity/test_slurm.py
@@ -657,7 +657,7 @@ def test_ldap_user_login_from_oim(host):
 
     result = verify_ldap_user_login_from_oim(host)
 
-    if result.get("error") and "not set in omnia_test_config" in result["error"]:
+    if result.get("error") and "not set in omnia_test" in result["error"]:
         log.skipped("LDAP credentials not configured", result["error"])
         pytest.skip(result["error"])
 
@@ -716,7 +716,7 @@ def test_ldap_user_login_from_core(host):
 
     result = verify_ldap_user_login_from_core(host)
 
-    if result.get("error") and "not set in omnia_test_config" in result["error"]:
+    if result.get("error") and "not set in omnia_test" in result["error"]:
         log.skipped("LDAP credentials not configured", result["error"])
         pytest.skip(result["error"])
 
@@ -774,7 +774,7 @@ def test_pam_slurm_adopt(host):
 
     result = verify_pam_slurm_adopt(host)
 
-    if result.get("error") and "not set in omnia_test_config" in result["error"]:
+    if result.get("error") and "not set in omnia_test" in result["error"]:
         log.skipped("LDAP credentials not configured", result["error"])
         pytest.skip(result["error"])
 
@@ -834,7 +834,7 @@ def test_pam_slurm_adopt_session_termination(host):
     result = verify_pam_slurm_adopt_session_termination(host)
 
     # Handle skip conditions
-    if result.get("error") and "not set in omnia_test_config" in result["error"]:
+    if result.get("error") and "not set in omnia_test" in result["error"]:
         log.skipped("LDAP credentials not configured", result["error"])
         pytest.skip(result["error"])
 

--- a/molecule/provision/tests/sanity/test_vector_telemetry.py
+++ b/molecule/provision/tests/sanity/test_vector_telemetry.py
@@ -57,6 +57,7 @@ from automation_library.telemetry.functions import (
     get_admin_ip,
     produce_test_message_to_kafka,
     skip_if_kafka_not_enabled,
+    skip_if_vector_not_enabled,
     verify_all_vector_configmaps,
     verify_no_plaintext_credentials,
     verify_vector_configmap_exists,
@@ -96,6 +97,7 @@ def test_vector_resource_compliance(host):
         log.skipped("No K8s nodes in PXE mapping", "Check PXE mapping file")
         pytest.skip("No K8s nodes in PXE mapping")
 
+    skip_if_vector_not_enabled(host, log)
     skip_if_kafka_not_enabled(host, log)
     admin_ip = get_admin_ip(host, log)
 
@@ -162,6 +164,7 @@ def test_vector_deployment_verification(host):
         log.skipped("No K8s nodes in PXE mapping", "Check PXE mapping file")
         pytest.skip("No K8s nodes in PXE mapping")
 
+    skip_if_vector_not_enabled(host, log)
     skip_if_kafka_not_enabled(host, log)
     admin_ip = get_admin_ip(host, log)
 
@@ -206,7 +209,7 @@ def test_vector_deployment_verification(host):
     if log_result["success"]:
         log.passed("No critical errors found in Vector logs", log_details)
     else:
-        log.warning(
+        log.skipped(
             f"Found {err_count} error entries in Vector logs", log_details
         )
 
@@ -229,6 +232,7 @@ def test_vector_configmap_exists(host):
         log.skipped("No K8s nodes in PXE mapping", "Check PXE mapping file")
         pytest.skip("No K8s nodes in PXE mapping")
 
+    skip_if_vector_not_enabled(host, log)
     skip_if_kafka_not_enabled(host, log)
     admin_ip = get_admin_ip(host, log)
 
@@ -264,6 +268,7 @@ def test_vector_self_metrics(host):
         log.skipped("No K8s nodes in PXE mapping", "Check PXE mapping file")
         pytest.skip("No K8s nodes in PXE mapping")
 
+    skip_if_vector_not_enabled(host, log)
     skip_if_kafka_not_enabled(host, log)
     admin_ip = get_admin_ip(host, log)
 
@@ -284,7 +289,7 @@ def test_vector_self_metrics(host):
     if result["success"]:
         log.passed("Vector self-metrics endpoint is accessible", details)
     else:
-        log.warning(
+        log.skipped(
             "Vector self-metrics endpoint verification incomplete", details
         )
 
@@ -305,6 +310,7 @@ def test_dynamic_topic_discovery(host):
         log.skipped("No K8s nodes in PXE mapping", "Check PXE mapping file")
         pytest.skip("No K8s nodes in PXE mapping")
 
+    skip_if_vector_not_enabled(host, log)
     skip_if_kafka_not_enabled(host, log)
     admin_ip = get_admin_ip(host, log)
 
@@ -323,7 +329,7 @@ def test_dynamic_topic_discovery(host):
     if result["success"]:
         log.passed(f"Kafka topic '{test_topic}' created", details)
     else:
-        log.warning(
+        log.skipped(
             f"Topic creation incomplete: {result.get('error', 'Unknown')}",
             details,
         )
@@ -345,6 +351,7 @@ def test_produce_test_message(host):
         log.skipped("No K8s nodes in PXE mapping", "Check PXE mapping file")
         pytest.skip("No K8s nodes in PXE mapping")
 
+    skip_if_vector_not_enabled(host, log)
     skip_if_kafka_not_enabled(host, log)
     admin_ip = get_admin_ip(host, log)
 
@@ -368,7 +375,7 @@ def test_produce_test_message(host):
     if result["success"]:
         log.passed("Test message produced to Kafka successfully", details)
     else:
-        log.warning(
+        log.skipped(
             f"Message production incomplete: "
             f"{result.get('error', 'Unknown')}",
             details,
@@ -396,6 +403,7 @@ def test_malformed_message_handling(host):
         log.skipped("No K8s nodes in PXE mapping", "Check PXE mapping file")
         pytest.skip("No K8s nodes in PXE mapping")
 
+    skip_if_vector_not_enabled(host, log)
     skip_if_kafka_not_enabled(host, log)
     admin_ip = get_admin_ip(host, log)
 
@@ -416,8 +424,8 @@ def test_malformed_message_handling(host):
     total = len(malformed_messages)
     details = f"Malformed messages produced: {count}/{total}"
 
-    log.info(
-        "Malformed messages produced for dead-letter routing test", details
+    log.check(
+        f"Malformed messages produced for dead-letter routing test — {details}"
     )
 
 
@@ -439,6 +447,7 @@ def test_vector_pipeline_recovery(host):
         log.skipped("No K8s nodes in PXE mapping", "Check PXE mapping file")
         pytest.skip("No K8s nodes in PXE mapping")
 
+    skip_if_vector_not_enabled(host, log)
     skip_if_kafka_not_enabled(host, log)
     admin_ip = get_admin_ip(host, log)
 
@@ -461,7 +470,7 @@ def test_vector_pipeline_recovery(host):
     log.passed(
         "Vector pods are running and ready for recovery testing", details
     )
-    log.info("Note: Pod deletion test is commented out for safety")
+    log.check("Note: Pod deletion test is commented out for safety")
 
 
 @pytest.mark.sanity
@@ -482,6 +491,7 @@ def test_runtime_transform_modification(host):
         log.skipped("No K8s nodes in PXE mapping", "Check PXE mapping file")
         pytest.skip("No K8s nodes in PXE mapping")
 
+    skip_if_vector_not_enabled(host, log)
     skip_if_kafka_not_enabled(host, log)
     admin_ip = get_admin_ip(host, log)
 
@@ -505,12 +515,12 @@ def test_runtime_transform_modification(host):
             "Vector ConfigMap contains transform configuration", details
         )
     else:
-        log.warning(
+        log.skipped(
             f"ConfigMap verification failed: "
             f"{result.get('error', 'Unknown')}"
         )
 
-    log.info("Note: Rollout restart test is commented out for safety")
+    log.check("Note: Rollout restart test is commented out for safety")
 
 
 # =============================================================================
@@ -534,6 +544,7 @@ def test_vector_redeployment_idempotency(host):
         log.skipped("No K8s nodes in PXE mapping", "Check PXE mapping file")
         pytest.skip("No K8s nodes in PXE mapping")
 
+    skip_if_vector_not_enabled(host, log)
     skip_if_kafka_not_enabled(host, log)
     admin_ip = get_admin_ip(host, log)
 
@@ -585,6 +596,7 @@ def test_mtls_authentication(host):
         log.skipped("No K8s nodes in PXE mapping", "Check PXE mapping file")
         pytest.skip("No K8s nodes in PXE mapping")
 
+    skip_if_vector_not_enabled(host, log)
     skip_if_kafka_not_enabled(host, log)
     admin_ip = get_admin_ip(host, log)
 
@@ -623,6 +635,7 @@ def test_no_plaintext_credentials(host):
         log.skipped("No K8s nodes in PXE mapping", "Check PXE mapping file")
         pytest.skip("No K8s nodes in PXE mapping")
 
+    skip_if_vector_not_enabled(host, log)
     skip_if_kafka_not_enabled(host, log)
     admin_ip = get_admin_ip(host, log)
 
@@ -668,6 +681,7 @@ def test_kafka_topics_exist(host):
         log.skipped("No K8s nodes in PXE mapping", "Check PXE mapping file")
         pytest.skip("No K8s nodes in PXE mapping")
 
+    skip_if_vector_not_enabled(host, log)
     skip_if_kafka_not_enabled(host, log)
     admin_ip = get_admin_ip(host, log)
 
@@ -687,7 +701,7 @@ def test_kafka_topics_exist(host):
         pytest.fail("Cannot get Kafka Bridge IP")
 
     kafka_lb_ip = cmd.stdout.strip()
-    log.info(f"Kafka Bridge IP: {kafka_lb_ip}")
+    log.check(f"Kafka Bridge IP: {kafka_lb_ip}")
 
     log.check("Querying Kafka topics via Bridge REST API")
     topics_cmd = run_on_remote_node(
@@ -725,7 +739,7 @@ def test_kafka_topics_exist(host):
             f"Found {len(found)}/{len(expected)} expected topics", details
         )
     else:
-        log.warning("No expected OME topics found", details)
+        log.skipped("No expected OME topics found", details)
 
 
 @pytest.mark.sanity
@@ -744,6 +758,7 @@ def test_query_victoria_metrics_ome_health(host):
         log.skipped("No K8s nodes in PXE mapping", "Check PXE mapping file")
         pytest.skip("No K8s nodes in PXE mapping")
 
+    skip_if_vector_not_enabled(host, log)
     skip_if_kafka_not_enabled(host, log)
     admin_ip = get_admin_ip(host, log)
 
@@ -759,11 +774,11 @@ def test_query_victoria_metrics_ome_health(host):
     )
 
     if cmd.rc != 0:
-        log.warning("Failed to get vmselect IP", cmd.stderr)
+        log.skipped("Failed to get vmselect IP", cmd.stderr)
         pytest.skip("Cannot get vmselect IP")
 
     vmselect_ip = cmd.stdout.strip()
-    log.info(f"VictoriaMetrics vmselect IP: {vmselect_ip}")
+    log.check(f"VictoriaMetrics vmselect IP: {vmselect_ip}")
 
     log.check("Querying OME health metrics from VictoriaMetrics")
     query = 'last_over_time({source_subsystem="ome",type="health"}[1h])'
@@ -780,7 +795,7 @@ def test_query_victoria_metrics_ome_health(host):
     )
 
     if query_cmd.rc != 0:
-        log.warning("Failed to query VictoriaMetrics", query_cmd.stderr)
+        log.skipped("Failed to query VictoriaMetrics", query_cmd.stderr)
         pytest.skip("Cannot query VictoriaMetrics")
 
     stdout = query_cmd.stdout.strip()
@@ -808,7 +823,7 @@ def test_query_victoria_metrics_ome_health(host):
             f"OME health metrics found ({result_count} results)", details
         )
     else:
-        log.warning(
+        log.skipped(
             "No OME health metrics found (may need time to ingest)",
             details,
         )
@@ -830,6 +845,7 @@ def test_query_victoria_logs_ome_auditlogs(host):
         log.skipped("No K8s nodes in PXE mapping", "Check PXE mapping file")
         pytest.skip("No K8s nodes in PXE mapping")
 
+    skip_if_vector_not_enabled(host, log)
     skip_if_kafka_not_enabled(host, log)
     admin_ip = get_admin_ip(host, log)
 
@@ -845,11 +861,11 @@ def test_query_victoria_logs_ome_auditlogs(host):
     )
 
     if cmd.rc != 0:
-        log.warning("Failed to get vlselect IP", cmd.stderr)
+        log.skipped("Failed to get vlselect IP", cmd.stderr)
         pytest.skip("Cannot get vlselect IP")
 
     vlselect_ip = cmd.stdout.strip()
-    log.info(f"VictoriaLogs vlselect IP: {vlselect_ip}")
+    log.check(f"VictoriaLogs vlselect IP: {vlselect_ip}")
 
     log.check("Querying OME audit logs from VictoriaLogs")
     query = "_msg_topic:ome.auditlogs"
@@ -865,7 +881,7 @@ def test_query_victoria_logs_ome_auditlogs(host):
     )
 
     if query_cmd.rc != 0:
-        log.warning("Failed to query VictoriaLogs", query_cmd.stderr)
+        log.skipped("Failed to query VictoriaLogs", query_cmd.stderr)
         pytest.skip("Cannot query VictoriaLogs")
 
     has_results = (
@@ -912,6 +928,6 @@ def test_query_victoria_logs_ome_auditlogs(host):
             f"OME audit logs found ({result_count} results)", details
         )
     else:
-        log.warning(
+        log.skipped(
             "No OME audit logs found (may need time to ingest)", details
         )

--- a/pytest.ini
+++ b/pytest.ini
@@ -17,3 +17,7 @@ markers =
     rollback: Rollback verification test cases (post-rollback state)
     regression: Regression test cases (full coverage across upgrade)
     idempotency: Idempotency verification test cases (re-run consistency)
+    dns: DNS and CoreDNS test cases
+    minimal_os: Minimal OS verification test cases
+    sanitygpu: Sanity test cases for GPU functionality
+    ufm_telemetry: UFM telemetry test cases


### PR DESCRIPTION
- Add skip_if_vector_not_enabled to all 15 vector telemetry tests
- Add is_vector_ldms_enabled, is_vector_ome_enabled, skip_if_vector_not_enabled to shared_func.py
- Export vector bridge check functions from telemetry __init__.py
- Add _skip_if_no_minimal_os skip helper to all 19 minimal_os tests
- Change DNS test_dns_configuration_enable from fail to skip when dns_enabled=false
- Add DNS skip checks to test_coresmd_container_deployment, test_dns_configuration_validation, test_invalid_domain_format_validation
- Fix LDAP skip condition substring match in 4 slurm tests (omnia_test_config -> omnia_test)
- Register dns, minimal_os, sanitygpu, ufm_telemetry markers in pytest.ini and conftest.py
- Fix log.info/log.warning calls in test_vector_telemetry.py (TestLogger compatibility)
- Add pylint disable for too-many-lines in test_coredns.py
- Remove unused ASSERT import and fix trailing whitespace in conftest.py